### PR TITLE
Debug placement

### DIFF
--- a/digiline.lua
+++ b/digiline.lua
@@ -205,7 +205,12 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 
 		if place_node_def.on_place ~= minetest.item_place then
 			-- non-default item placement, use custom function (crops, other items)
-			local itemstack = ItemStack(msg.name .. " 1")
+			-- taking an actual item instead of creating a new stack,
+			-- raises the chances that we get something useful
+			local itemstack = inv:remove_item("main", msg.name)
+			if is_creative and itemstack:is_empty() then
+				itemstack = ItemStack(msg.name .. " 1")
+			end
 			local returnstack, success = place_node_def.on_place(ItemStack(itemstack), player, pointed_thing)
 			if returnstack and returnstack:get_count() < itemstack:get_count() then
 				success = true

--- a/digiline.lua
+++ b/digiline.lua
@@ -212,10 +212,19 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 				itemstack = ItemStack(msg.name .. " 1")
 			end
 			local returnstack, success = place_node_def.on_place(ItemStack(itemstack), player, pointed_thing)
-			if returnstack and returnstack:get_count() < itemstack:get_count() then
-				success = true
+			if returnstack then
+				return_stack(pos, inv, returnstack)
+				if returnstack:get_wear() ~= itemstack:get_wear()
+					or returnstack:get_name() ~= itemstack:get_name()
+					or returnstack:get_count() < itemstack:get_count() then
+						success = true
+				end
 			end
 			if not success then
+				if not returnstack then
+					-- some items aren't placed but don't return a stack
+					return_stack(pos, inv, itemstack)
+				end
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
 					error = true,
@@ -226,6 +235,9 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		else
 			-- default on_place, use `set_node` to avoid side-effects (on-place rotations)
 			minetest.set_node(absolute_pos, place_node)
+			if not is_creative then
+				inv:remove_item("main", msg.name)
+			end
 		end
 
 		-- check if "after_place_node" is defined

--- a/digiline.lua
+++ b/digiline.lua
@@ -330,10 +330,10 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		-- checking if param2 actually is what was requested
 		if enable_param2 then
 			local check_node = digibuilder.get_node(absolute_pos)
-			if check_node.name ~= msg.name then
-				-- this is not always a bad sign, certain nodes change their name (or fall)
-				-- also itemname and nodename don't always match
-			elseif check_node.param2 ~= place_node.param2 then
+			-- it is not always a bad sign when name of placed node does
+			-- not match itemname, certain nodes change their name (or fall)
+			-- also itemname and nodename don't always match
+			if check_node.name == msg.name and check_node.param2 ~= place_node.param2 then
 				-- enforce param2
 				minetest.swap_node(absolute_pos, place_node)
 			end

--- a/digiline.lua
+++ b/digiline.lua
@@ -120,6 +120,9 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 			end
 
 			-- check if node is in inventory
+			-- this check does not work for items like technic:water_can
+			-- it may be in inventory but empty. Using an empty can with
+			-- digibuilder destroys it!
 			if not inv:contains_item("main", msg.name) then
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
@@ -207,6 +210,8 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 			-- non-default item placement, use custom function (crops, other items)
 			-- taking an actual item instead of creating a new stack,
 			-- raises the chances that we get something useful
+			-- TODO: search for best match e.g. full can instead of empty one
+			--local inv_list = inv:get_list("main")
 			local itemstack = inv:remove_item("main", msg.name)
 			if is_creative and itemstack:is_empty() then
 				itemstack = ItemStack(msg.name .. " 1")

--- a/digiline.lua
+++ b/digiline.lua
@@ -212,6 +212,8 @@ print('param2 disabled')
 			pointed_thing.under.z = absolute_pos.z - 1
 		elseif msg.north == true then
 			pointed_thing.under.z = absolute_pos.z + 1
+		elseif msg.neutral == true then
+			-- nothing to do
 		else
 			pointed_thing.under.y = absolute_pos.y - 1
 			if place_node_def.paramtype2 == "facedir" then

--- a/digiline.lua
+++ b/digiline.lua
@@ -213,6 +213,11 @@ print('param2 disabled')
 			place_node.param2 = 0
 		end
 
+		if place_node_def.place_param2 ~= nil then
+			-- use predefined param2
+			place_node.param2 = place_node_def.place_param2
+		end
+
 		-- place node inworld
 		minetest.log("action", "[digibuilder] " .. owner .. " places node '" ..
 			place_node.name .. "' at " ..
@@ -281,12 +286,6 @@ print('param2 disabled')
 			else
 				pointed_thing.under.y = absolute_pos.y - 1
 			end
-		end
-
-		if place_node_def.place_param2 ~= nil then
-print('using predefined param2')
-			-- use predefined param2
-			place_node.param2 = place_node_def.place_param2
 		end
 
 		if place_node_def.on_place ~= minetest.item_place then

--- a/digiline.lua
+++ b/digiline.lua
@@ -35,6 +35,7 @@ local function best_inventory_index(inv, itemname)
 		end
 		index = index - 1
 	until index == 0
+print('best index: >>'..dump(best_index)..'<<')
 	return best_index
 end
 
@@ -214,6 +215,7 @@ print('param2 disabled')
 		end
 
 		if place_node_def.place_param2 ~= nil then
+print('using predefined param2')
 			-- use predefined param2
 			place_node.param2 = place_node_def.place_param2
 		end
@@ -293,6 +295,7 @@ print('non default item placement')
 			-- non-default item placement, use custom function (crops, other items)
 			-- taking an actual item instead of creating a new stack,
 			-- raises the chances that we get something useful
+print('best index>'..dump(inv_best_index)..'<')
 			local itemstack
 			if is_creative and inv_best_index == nil then
 				itemstack = ItemStack(msg.name .. " 1")
@@ -302,6 +305,7 @@ print('non default item placement')
 				-- delete slot
 				inv:set_stack("main", inv_best_index, ItemStack("")) --inv:remove_item("main", msg.name)
 			end
+print('wear '..itemstack:get_wear())
 			local returnstack, success = place_node_def.on_place(ItemStack(itemstack), player, pointed_thing)
 print('>'..dump(returnstack and returnstack:to_string() or 'nil')..'<>'..dump(success)..'<')
 			if returnstack then

--- a/digiline.lua
+++ b/digiline.lua
@@ -183,12 +183,19 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		local pointed_thing = {}
 		pointed_thing.type = "node"
 		pointed_thing.above = {x=absolute_pos.x, y=absolute_pos.y, z=absolute_pos.z}
-		pointed_thing.under = {x=absolute_pos.x, y=absolute_pos.y-1, z=absolute_pos.z}
-
-		if place_node_def.paramtype2 == "facedir" then
-			pointed_thing.under = vector.add(absolute_pos, minetest.facedir_to_dir(param2))
-		elseif place_node_def.paramtype2 == "wallmounted" then
-			pointed_thing.under = vector.add(absolute_pos, minetest.wallmounted_to_dir(param2))
+		pointed_thing.under = {x=absolute_pos.x, y=absolute_pos.y, z=absolute_pos.z}
+		if msg.up == true then
+			pointed_thing.under.y = absolute_pos.y + 1
+		elseif msg.down == true then
+			pointed_thing.under.y = absolute_pos.y - 1
+		elseif msg.west == true then
+			pointed_thing.under.x = absolute_pos.x - 1
+		elseif msg.east == true then
+			pointed_thing.under.x = absolute_pos.x + 1
+		elseif msg.south == true then
+			pointed_thing.under.z = absolute_pos.z - 1
+		elseif msg.north == true then
+			pointed_thing.under.z = absolute_pos.z + 1
 		end
 
 		if place_node_def.place_param2 ~= nil then

--- a/digiline.lua
+++ b/digiline.lua
@@ -9,6 +9,15 @@ function digibuilder.get_node(pos)
 	return node
 end
 
+local function return_stack(pos, inv, stack)
+	if stack:is_empty() then return end
+	local overflow_stack = inv:add_item("main", stack)
+	if not overflow_stack:is_empty() then
+		-- TODO: discuss if items should be dropped at absolute_pos or pos
+		minetest.add_item(pos, overflow_stack)
+	end
+end
+
 function digibuilder.digiline_effector(pos, _, channel, msg)
 
 	-- only allow table message types

--- a/digiline.lua
+++ b/digiline.lua
@@ -180,7 +180,7 @@ print('param2 enabled: '..param2)
 		else
 print('param2 disabled')
 			-- set default param2
-			param2 = 0
+			place_node.param2 = 0
 		end
 
 		-- place node inworld
@@ -243,7 +243,8 @@ print('wear after: '.. returnstack:get_wear())
 					or returnstack:get_count() < itemstack:get_count() then
 						success = true
 				end
-print('used ' .. msg.name .. ', returned: >' .. returnstack:to_string() .. '< c ' .. returnstack:get_count() .. ' }' .. itemstack:to_string())
+print('used ' .. msg.name .. ', returned: >' .. returnstack:to_string()
+.. '< c ' .. returnstack:get_count() .. ' }' .. itemstack:to_string())
 			end
 			if not success then
 print('no success')
@@ -301,3 +302,4 @@ print('target is now: '.. dump(digibuilder.get_node(absolute_pos)))
 		})
 	end
 end
+

--- a/digiline.lua
+++ b/digiline.lua
@@ -219,12 +219,38 @@ print('param2 disabled')
 			minetest.pos_to_string(absolute_pos)
 		)
 
+		local dir = minetest.facedir_to_dir(place_node.param2)
+		local pitch
+		local yaw
+		if dir.z < 0 then
+			yaw = 0
+			pitch = 0
+		elseif dir.z > 0 then
+			yaw = math.pi
+			pitch = 0
+		elseif dir.x < 0 then
+			yaw = 3*math.pi/2
+			pitch = 0
+		elseif dir.x > 0 then
+			yaw = math.pi/2
+			pitch = 0
+		elseif dir.y > 0 then
+			yaw = 0
+			pitch = -math.pi/2
+		else
+			yaw = 0
+			pitch = math.pi/2
+		end
 		-- create fake player for certain function arguments (after_place_node, etc)
 		local player = digibuilder.create_fake_player({
 			name = owner,
 			inventory = inv,
 			wield_list = "main",
-			wield_index = inv_best_index
+			wield_index = inv_best_index,
+			position = vector.subtract(absolute_pos, vector.new(0, 1.5, 0)),
+			look_dir = vector.multiply(dir, -1),
+			look_pitch = pitch,
+			look_yaw = yaw
 		})
 
 		-- see:

--- a/digiline.lua
+++ b/digiline.lua
@@ -151,11 +151,6 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 			return
 		end
 
-		if not is_creative then
-			-- remove item
-			inv:remove_item("main", msg.name)
-		end
-
 		-- only allow param2 setting for "facedir" types
 		local param2 = tonumber(msg.param2) or 0
 		local enable_param2 = place_node_def.paramtype2 == "facedir" and param2 and param2 > 0 and param2 <= 255

--- a/digiline.lua
+++ b/digiline.lua
@@ -36,6 +36,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		return
 	end
 
+print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
 	-- validate position
 	local owner = meta:get_string("owner")
 	if not digibuilder.digiline_validate_pos(pos, owner, set_channel, msg) then
@@ -92,7 +93,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		-- calculate absolute position
 		local absolute_pos = vector.add(pos, msg.pos)
 		local node = digibuilder.get_node(absolute_pos)
-
+print('target: ' .. node.name)
 		-- get and validate node definition
 		local node_def = minetest.registered_nodes[node.name]
 		if not node_def then
@@ -109,8 +110,10 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 
 
 		if not is_creative then
+print('not creative')
 			-- check if node is buildable to
 			if not node_def.buildable_to then
+print('target not buildable_to')
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
 					error = true,
@@ -124,6 +127,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 			-- it may be in inventory but empty. Using an empty can with
 			-- digibuilder destroys it!
 			if not inv:contains_item("main", msg.name) then
+print('item not in inventory')
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
 					error = true,
@@ -132,7 +136,13 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 				return
 			end
 		end
-
+--[[
+for n,d in pairs(minetest.registered_items) do
+	if d.paramtype2 == 'wallmounted' then
+		print(n)
+	end
+end
+--]]
 		-- get and validate place node definition
 		local place_node_def = minetest.registered_items[msg.name]
 		if not place_node_def then
@@ -145,6 +155,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		end
 
 		if not place_node_def.on_place then
+print('place_node_def does not have on_place')
 			-- can't place node
 			digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 				pos = msg.pos,
@@ -163,9 +174,11 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		}
 
 		if enable_param2 then
+print('param2 enabled: '..param2)
 			-- place with param2 info
 			place_node.param2 = param2
 		else
+print('param2 disabled')
 			-- set default param2
 			param2 = 0
 		end
@@ -202,30 +215,38 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		end
 
 		if place_node_def.place_param2 ~= nil then
+print('using predefined param2')
 			-- use predefined param2
 			place_node.param2 = place_node_def.place_param2
 		end
 
 		if place_node_def.on_place ~= minetest.item_place then
+print('non default item placement')
 			-- non-default item placement, use custom function (crops, other items)
 			-- taking an actual item instead of creating a new stack,
 			-- raises the chances that we get something useful
 			-- TODO: search for best match e.g. full can instead of empty one
 			--local inv_list = inv:get_list("main")
+--print(dump(inv_list))
 			local itemstack = inv:remove_item("main", msg.name)
+print('wear '..itemstack:get_wear())
 			if is_creative and itemstack:is_empty() then
 				itemstack = ItemStack(msg.name .. " 1")
 			end
 			local returnstack, success = place_node_def.on_place(ItemStack(itemstack), player, pointed_thing)
+print('>'..dump(returnstack and returnstack:to_string() or 'nil')..'<>'..dump(success)..'<')
 			if returnstack then
+print('wear after: '.. returnstack:get_wear())
 				return_stack(pos, inv, returnstack)
 				if returnstack:get_wear() ~= itemstack:get_wear()
 					or returnstack:get_name() ~= itemstack:get_name()
 					or returnstack:get_count() < itemstack:get_count() then
 						success = true
 				end
+print('used ' .. msg.name .. ', returned: >' .. returnstack:to_string() .. '< c ' .. returnstack:get_count() .. ' }' .. itemstack:to_string())
 			end
 			if not success then
+print('no success')
 				if not returnstack then
 					-- some items aren't placed but don't return a stack
 					return_stack(pos, inv, itemstack)
@@ -238,6 +259,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 				return
 			end
 		else
+print('placing with core.set_node')
 			-- default on_place, use `set_node` to avoid side-effects (on-place rotations)
 			minetest.set_node(absolute_pos, place_node)
 			if not is_creative then
@@ -247,6 +269,7 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 
 		-- check if "after_place_node" is defined
 		if place_node_def.after_place_node then
+print('has after_place_node')
 			place_node_def.after_place_node(absolute_pos, player, ItemStack(), pointed_thing)
 		end
 
@@ -256,12 +279,17 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		-- checking if param2 actually is what was requested
 		if enable_param2 then
 			local check_node = digibuilder.get_node(absolute_pos)
+print('placed is '.. dump(check_node))
+print('to place is '.. dump(place_node))
 			if check_node.name ~= msg.name then
 				-- this is not always a bad sign, certain nodes change their name (or fall)
 				-- also itemname and nodename don't always match
+print('not expected node at target, new name: ' .. check_node.name)
 			elseif check_node.param2 ~= place_node.param2 then
+print('enforcing swap_node')
 				-- enforce param2
 				minetest.swap_node(absolute_pos, place_node)
+print('target is now: '.. dump(digibuilder.get_node(absolute_pos)))
 			end
 		end
 

--- a/digiline.lua
+++ b/digiline.lua
@@ -247,6 +247,7 @@ print('param2 disabled')
 			pointed_thing.under.z = absolute_pos.z + 1
 		elseif msg.neutral == true then
 			-- nothing to do
+			pointed_thing = pointed_thing
 		else
 			pointed_thing.under.y = absolute_pos.y - 1
 			if place_node_def.paramtype2 == "facedir" then

--- a/digiline.lua
+++ b/digiline.lua
@@ -259,6 +259,8 @@ print('param2 disabled')
 		pointed_thing.type = "node"
 		pointed_thing.above = {x=absolute_pos.x, y=absolute_pos.y, z=absolute_pos.z}
 		pointed_thing.under = {x=absolute_pos.x, y=absolute_pos.y, z=absolute_pos.z}
+		-- Note: it is intentional that the default is a
+		-- neutral (non-directional) pointed_thing
 		if msg.up == true then
 			pointed_thing.under.y = absolute_pos.y + 1
 		elseif msg.down == true then
@@ -271,15 +273,13 @@ print('param2 disabled')
 			pointed_thing.under.z = absolute_pos.z - 1
 		elseif msg.north == true then
 			pointed_thing.under.z = absolute_pos.z + 1
-		elseif msg.neutral == true then
-			-- nothing to do
-			pointed_thing = pointed_thing
-		else
-			pointed_thing.under.y = absolute_pos.y - 1
+		elseif msg.auto == true then
 			if place_node_def.paramtype2 == "facedir" then
-				pointed_thing.under = vector.add(absolute_pos, minetest.facedir_to_dir(param2))
+				pointed_thing.under = vector.add(absolute_pos, minetest.facedir_to_dir(place_node.param2))
 			elseif place_node_def.paramtype2 == "wallmounted" then
-				pointed_thing.under = vector.add(absolute_pos, minetest.wallmounted_to_dir(param2))
+				pointed_thing.under = vector.add(absolute_pos, minetest.wallmounted_to_dir(place_node.param2))
+			else
+				pointed_thing.under.y = absolute_pos.y - 1
 			end
 		end
 

--- a/digiline.lua
+++ b/digiline.lua
@@ -35,7 +35,7 @@ local function best_inventory_index(inv, itemname)
 		end
 		index = index - 1
 	until index == 0
-print('best index: >>'..dump(best_index)..'<<')
+
 	return best_index
 end
 
@@ -67,7 +67,6 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		return
 	end
 
-print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
 	-- validate position
 	local owner = meta:get_string("owner")
 	if not digibuilder.digiline_validate_pos(pos, owner, set_channel, msg) then
@@ -124,7 +123,7 @@ print('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
 		-- calculate absolute position
 		local absolute_pos = vector.add(pos, msg.pos)
 		local node = digibuilder.get_node(absolute_pos)
-print('target: ' .. node.name)
+
 		-- get and validate node definition
 		local node_def = minetest.registered_nodes[node.name]
 		if not node_def then
@@ -141,10 +140,8 @@ print('target: ' .. node.name)
 		local inv_best_index = best_inventory_index(inv, msg.name)
 
 		if not is_creative then
-print('not creative')
 			-- check if node is buildable to
 			if not node_def.buildable_to then
-print('target not buildable_to')
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
 					error = true,
@@ -158,7 +155,6 @@ print('target not buildable_to')
 			-- it may be in inventory but empty. Using an empty can with
 			-- digibuilder destroys it!
 			if not inv_best_index then
-print('item not in inventory')
 				digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 					pos = msg.pos,
 					error = true,
@@ -167,13 +163,7 @@ print('item not in inventory')
 				return
 			end
 		end
---[[
-for n,d in pairs(minetest.registered_items) do
-	if d.paramtype2 == 'wallmounted' then
-		print(n)
-	end
-end
---]]
+
 		-- get and validate place node definition
 		local place_node_def = minetest.registered_items[msg.name]
 		if not place_node_def then
@@ -186,7 +176,6 @@ end
 		end
 
 		if not place_node_def.on_place then
-print('place_node_def does not have on_place')
 			-- can't place node
 			digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 				pos = msg.pos,
@@ -205,17 +194,14 @@ print('place_node_def does not have on_place')
 		}
 
 		if enable_param2 then
-print('param2 enabled: '..param2)
 			-- place with param2 info
 			place_node.param2 = param2
 		else
-print('param2 disabled')
 			-- set default param2
 			place_node.param2 = 0
 		end
 
 		if place_node_def.place_param2 ~= nil then
-print('using predefined param2')
 			-- use predefined param2
 			place_node.param2 = place_node_def.place_param2
 		end
@@ -291,11 +277,9 @@ print('using predefined param2')
 		end
 
 		if place_node_def.on_place ~= minetest.item_place then
-print('non default item placement')
 			-- non-default item placement, use custom function (crops, other items)
 			-- taking an actual item instead of creating a new stack,
 			-- raises the chances that we get something useful
-print('best index>'..dump(inv_best_index)..'<')
 			local itemstack
 			if is_creative and inv_best_index == nil then
 				itemstack = ItemStack(msg.name .. " 1")
@@ -305,22 +289,17 @@ print('best index>'..dump(inv_best_index)..'<')
 				-- delete slot
 				inv:set_stack("main", inv_best_index, ItemStack("")) --inv:remove_item("main", msg.name)
 			end
-print('wear '..itemstack:get_wear())
+
 			local returnstack, success = place_node_def.on_place(ItemStack(itemstack), player, pointed_thing)
-print('>'..dump(returnstack and returnstack:to_string() or 'nil')..'<>'..dump(success)..'<')
 			if returnstack then
-print('wear after: '.. returnstack:get_wear())
 				return_stack(pos, inv, returnstack)
 				if returnstack:get_wear() ~= itemstack:get_wear()
 					or returnstack:get_name() ~= itemstack:get_name()
 					or returnstack:get_count() < itemstack:get_count() then
 						success = true
 				end
-print('used ' .. msg.name .. ', returned: >' .. returnstack:to_string()
-.. '< c ' .. returnstack:get_count() .. ' }' .. itemstack:to_string())
 			end
 			if not success then
-print('no success')
 				if not returnstack then
 					-- some items aren't placed but don't return a stack
 					return_stack(pos, inv, itemstack)
@@ -333,7 +312,6 @@ print('no success')
 				return
 			end
 		else
-print('placing with core.set_node')
 			-- default on_place, use `set_node` to avoid side-effects (on-place rotations)
 			minetest.set_node(absolute_pos, place_node)
 			if not is_creative then
@@ -343,7 +321,6 @@ print('placing with core.set_node')
 
 		-- check if "after_place_node" is defined
 		if place_node_def.after_place_node then
-print('has after_place_node')
 			place_node_def.after_place_node(absolute_pos, player, ItemStack(), pointed_thing)
 		end
 
@@ -353,17 +330,12 @@ print('has after_place_node')
 		-- checking if param2 actually is what was requested
 		if enable_param2 then
 			local check_node = digibuilder.get_node(absolute_pos)
-print('placed is '.. dump(check_node))
-print('to place is '.. dump(place_node))
 			if check_node.name ~= msg.name then
 				-- this is not always a bad sign, certain nodes change their name (or fall)
 				-- also itemname and nodename don't always match
-print('not expected node at target, new name: ' .. check_node.name)
 			elseif check_node.param2 ~= place_node.param2 then
-print('enforcing swap_node')
 				-- enforce param2
 				minetest.swap_node(absolute_pos, place_node)
-print('target is now: '.. dump(digibuilder.get_node(absolute_pos)))
 			end
 		end
 

--- a/digiline.lua
+++ b/digiline.lua
@@ -212,6 +212,9 @@ print('param2 disabled')
 			pointed_thing.under.z = absolute_pos.z - 1
 		elseif msg.north == true then
 			pointed_thing.under.z = absolute_pos.z + 1
+		else
+			pointed_thing.under.y = absolute_pos.y - 1
+			
 		end
 
 		if place_node_def.place_param2 ~= nil then

--- a/digiline.lua
+++ b/digiline.lua
@@ -214,7 +214,11 @@ print('param2 disabled')
 			pointed_thing.under.z = absolute_pos.z + 1
 		else
 			pointed_thing.under.y = absolute_pos.y - 1
-			
+			if place_node_def.paramtype2 == "facedir" then
+				pointed_thing.under = vector.add(absolute_pos, minetest.facedir_to_dir(param2))
+			elseif place_node_def.paramtype2 == "wallmounted" then
+				pointed_thing.under = vector.add(absolute_pos, minetest.wallmounted_to_dir(param2))
+			end
 		end
 
 		if place_node_def.place_param2 ~= nil then

--- a/digiline.lua
+++ b/digiline.lua
@@ -248,6 +248,18 @@ function digibuilder.digiline_effector(pos, _, channel, msg)
 		-- check if the node is falling
 		minetest.check_for_falling(absolute_pos)
 
+		-- checking if param2 actually is what was requested
+		if enable_param2 then
+			local check_node = digibuilder.get_node(absolute_pos)
+			if check_node.name ~= msg.name then
+				-- this is not always a bad sign, certain nodes change their name (or fall)
+				-- also itemname and nodename don't always match
+			elseif check_node.param2 ~= place_node.param2 then
+				-- enforce param2
+				minetest.swap_node(absolute_pos, place_node)
+			end
+		end
+
 		digilines.receptor_send(pos, digibuilder.digiline_rules, set_channel, {
 			pos = msg.pos,
 			name = place_node.name,

--- a/examples/cable_plates.lua
+++ b/examples/cable_plates.lua
@@ -1,0 +1,44 @@
+-- places a stone above digibuilder, then surrounds it with
+-- cable-plates so that the big flat end lies against the stone
+
+-- list of setnode commands
+local s = "technic:hv_cable_plate_1"
+local data = {
+	{ name = "default:stone", pos = { x = 0, y = 2, z = 0 } },
+	{ name = s, up = true, pos = { x = 0, y = 1, z = 0 } },
+	{ name = s, down = true, pos = { x = 0, y = 3, z = 0 } },
+	{ name = s, north = true, pos = { x = 0, y = 2, z = -1 } },
+	{ name = s, south = true, pos = { x = 0, y = 2, z = 1 } },
+	{ name = s, west = true, pos = { x = 1, y = 2, z = 0 } },
+	{ name = s, east = true, pos = { x = -1, y = 2, z = 0 } }
+}
+
+-- initial start
+if event.type == "program" then
+	mem.pos = 1
+	interrupt(1)
+end
+
+-- timer interrupt
+if event.type == "interrupt" then
+	local entry = data[mem.pos]
+	if not entry then
+		-- done
+		return
+	end
+
+	entry.command = "setnode"
+	digiline_send("digibuilder", entry)
+end
+
+-- callback from digibuilder node
+if event.type == "digiline" and event.channel == "digibuilder" then
+	if event.error then
+		-- error state
+		error(event.message)
+	end
+
+	-- next command
+	mem.pos = mem.pos + 1
+	interrupt(1)
+end

--- a/examples/slabs_and_water.lua
+++ b/examples/slabs_and_water.lua
@@ -1,0 +1,45 @@
+-- places a box of slabs and places water inside it
+
+local s = "moreblocks:slab_super_glow_glass_1"
+local w = "bucket:bucket_river_water"
+-- list of setnode commands
+local data = {
+	{ name = s, param2 = 21, pos = { x = 0, y = 1, z = 0 } },
+	{ name = s, param2 = 3, pos = { x = 0, y = 3, z = 0 } },
+	{ name = s, param2 = 11, pos = { x = 0, y = 2, z = -1 } },
+	{ name = s, param2 = 5, pos = { x = 0, y = 2, z = 1 } },
+	{ name = s, param2 = 12, pos = { x = 1, y = 2, z = 0 } },
+	{ name = s, param2 = 18, pos = { x = -1, y = 2, z = 0 } },
+	{ name = w, pos = { x = 0, y = 2, z = 0 }
+	}
+}
+
+-- initial start
+if event.type == "program" then
+	mem.pos = 1
+	interrupt(1)
+end
+
+-- timer interrupt
+if event.type == "interrupt" then
+	local entry = data[mem.pos]
+	if not entry then
+		-- done
+		return
+	end
+
+	entry.command = "setnode"
+	digiline_send("digibuilder", entry)
+end
+
+-- callback from digibuilder node
+if event.type == "digiline" and event.channel == "digibuilder" then
+	if event.error then
+		-- error state
+		error(event.message)
+	end
+
+	-- next command
+	mem.pos = mem.pos + 1
+	interrupt(1)
+end

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,15 @@ if event.type == "digiline" and event.channel == "digibuilder" then
 end
 ```
 
+### pointed_thing handling
+
+If none of the fields { up, down, north, south, west, east, auto } are set to true
+then a zero orientational pointed_thing is used. i.e. under == above coordinates.
+If auto field is set to true, then a direction is set based on the evaluated param2
+or falls back to downward direction.
+Some nodes need a support-node to be at under position or they will be placed in
+the resulting under-coordinate. e.g. technic:hv_cable_plate_1
+
 # Examples
 
 For code examples for the `luacontroller` see the "examples" directory


### PR DESCRIPTION
Seeds still do not work. (except mushrooms and sapplings)
These changes however largely improve item handling and placement of cut nodes.
See the individual commit comments.

I've attached world-edit models of a small test setup:
dibuDemoOrig.we - original setup that was copied, code included. Only the tube and the water needed changing. Also I added pointed_thing modifiers to the letters.
dibuDemoResult.we - the result I got. 1/4 letters worked, so still improvement needed.
dibuDemoMT.we - an empty build setup ready for use. The button in front of luac is the play/pause button. The one to the right(opposite the LCD) is a reset button.
[dibuDemo.zip](https://github.com/BuckarooBanzay/digibuilder/files/11591344/dibuDemo.zip)

Edit: the seeds I tried now work if you add 'down' field in message.

potentially closes #9
